### PR TITLE
Example Fix for GHCJS Builds

### DIFF
--- a/data-validation.cabal
+++ b/data-validation.cabal
@@ -29,15 +29,16 @@ library
   default-language:   Haskell2010
   ghc-options:       -Wall -v0
 
-library examples
-  exposed-modules:    Examples.Data.ComplexTypes
-                    , Examples.Data.Primitives
-  build-depends:      base >= 4.11.0.1 && < 5
-                    , data-validation
-                    , regex-tdfa
-  hs-source-dirs:     examples
-  default-language:   Haskell2010
-  ghc-options:       -Wall -v0
+if !(impl(ghcjs))
+  library examples
+    exposed-modules:    Examples.Data.ComplexTypes
+                      , Examples.Data.Primitives
+    build-depends:      base >= 4.11.0.1 && < 5
+                      , data-validation
+                      , regex-tdfa
+    hs-source-dirs:     examples
+    default-language:   Haskell2010
+    ghc-options:       -Wall -v0
 
 test-suite test-data-validation
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
Unclear errors occurred when attempting to drop into ghcjs nix shell, this only started happening after addition of examples library to cabal. The error is below, but I think the actual issue is between `regex-tdfa` and `ghcjs`. Since regex is not integral to this library the solution is just to not define the example library when using ghcjs. 
```bash
Installing library in /nix/store/6ndcsb0rblvmrgzk6pmwhyxqnnfrw50q-data-validation-0.1.2.0/lib/ghcjs-8.6.0.1/x86_64-linux-ghcjs-8.6.0.1-ghc8_6_5/data-validation-0.1.2.0-DcqOB9GYUYxBfNM3TmlKTn
Installing internal library examples in /nix/store/6ndcsb0rblvmrgzk6pmwhyxqnnfrw50q-data-validation-0.1.2.0/lib/ghcjs-8.6.0.1/x86_64-linux-ghcjs-8.6.0.1-ghc8_6_5/data-validation-0.1.2.0-IxpZEpdQBzT323lgmnNnZK-examples
Setup: Error: Could not find module: Examples.Data.ComplexTypes with any
suffix: ["js_hi"] in the search path: ["dist/build/examples"]
builder for '/nix/store/ppqdpa7zwaf2mhqvmlifarpxsvrflf7s-data-validation-0.1.2.0.drv' failed with exit code 1
cannot build derivation '/nix/store/wq6bypp390q3kr7k58817ibf78w5c9yp-ghcjs-8.6.0.1-with-packages.drv': 1 dependencies couldn't be built
error: build of '/nix/store/wq6bypp390q3kr7k58817ibf78w5c9yp-ghcjs-8.6.0.1-with-packages.drv' failed
```