### PR TITLE
Cabal conditional library fix

### DIFF
--- a/data-validation.cabal
+++ b/data-validation.cabal
@@ -29,8 +29,8 @@ library
   default-language:   Haskell2010
   ghc-options:       -Wall -v0
 
-if !(impl(ghcjs))
-  library examples
+library examples
+  if !(impl(ghcjs))
     exposed-modules:    Examples.Data.ComplexTypes
                       , Examples.Data.Primitives
     build-depends:      base >= 4.11.0.1 && < 5


### PR DESCRIPTION
When uploading to hackage found the package failed with warning about new `if` in cabal file. Learned that package can be validated locally using `cabal check`. Moved `if` into library stanza, and verified valid package. Also verified that this still builds as expected for ghcjs projects.