### PR TITLE
Executable Example

### DIFF
--- a/data-validation.cabal
+++ b/data-validation.cabal
@@ -29,14 +29,14 @@ library
   default-language:   Haskell2010
   ghc-options:       -Wall -v0
 
-library examples
-  if !(impl(ghcjs))
-    exposed-modules:    Examples.Data.ComplexTypes
+executable examples-exe
+    hs-source-dirs:     examples, examples/Examples/Data
+    main-is:            Main.hs
+    other-modules:      Examples.Data.ComplexTypes
                       , Examples.Data.Primitives
     build-depends:      base >= 4.11.0.1 && < 5
                       , data-validation
                       , regex-tdfa
-    hs-source-dirs:     examples
     default-language:   Haskell2010
     ghc-options:       -Wall -v0
 

--- a/examples/Examples/Data/Main.hs
+++ b/examples/Examples/Data/Main.hs
@@ -1,0 +1,51 @@
+module Main where
+
+------------------------------------------------------------------------------------------------------------------------
+import Prelude
+import Data.Validation
+------------------------------------------------------------------------------------------------------------------------
+import Examples.Data.ComplexTypes
+import Examples.Data.Primitives
+------------------------------------------------------------------------------------------------------------------------
+
+-- make some space
+header :: IO ()
+header = do
+  putStrLn "\n"
+  putStrLn "Basic data-validation usage example:"
+  putStrLn "\n"
+
+-- only prints contents of valid proof
+printValid :: Proof MyFailures User -> IO ()
+printValid (Valid user) = do
+  putStrLn "--- Valid User ---"
+  putStrLn $ show user
+  putStrLn "\n"
+printValid _ = pure ()
+
+-- only prints invalid proof
+printInvalid :: Proof MyFailures User -> IO ()
+printInvalid (Valid _) = pure ()
+printInvalid failure = do
+  putStrLn "--- Invalid Proof ---"
+  putStrLn $ show failure
+  putStrLn "\n"
+
+-- very basic usage example showcasing types defined in ComplexTypes and Primitives modules
+main :: IO ()
+main = do
+  header
+      -- populate forms
+  let validForm = UserVM (Just "Hugh Mann") (Just "person@earth.com") Nothing (Just Email) Nothing
+      invalidForm = UserVM (Just "broken") Nothing (Just "123") (Just Email) Nothing
+      -- validate proofs
+      userProof = validate validForm
+      userFailure = validate invalidForm
+  -- prints user
+  printValid userProof
+  -- prints nothing
+  printInvalid userProof
+  -- prints failure
+  printInvalid userFailure
+  -- prints nothing
+  printValid userFailure


### PR DESCRIPTION
Found that having example library defined in cabal was causing data-validation to be listed as it's own dependency on Hackage.  https://hackage.haskell.org/package/data-validation-0.1.2.2. Making this example an executable instead to avoid this circular dependency with the library.