### PR TITLE
Loosen Cabal Constraint

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-haskell@v1
       with:
         ghc-version: ${{ matrix.ghc-version }}
-        cabal-version: '3.0'
+        cabal-version: '2.0'
 
     - name: Cache
       uses: actions/cache@v1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-haskell@v1
       with:
         ghc-version: ${{ matrix.ghc-version }}
-        cabal-version: '2.0'
+        cabal-version: '3.0'
 
     - name: Cache
       uses: actions/cache@v1

--- a/data-validation.cabal
+++ b/data-validation.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.4
+cabal-version:       >=1.10
 name:                data-validation
 version:             0.1.2.4
 synopsis:            A library for creating type safe validations.

--- a/data-validation.cabal
+++ b/data-validation.cabal
@@ -11,6 +11,7 @@ author:              Ampersand
 maintainer:          Ampersand <software@ampersandtech.com>
 copyright:           2020 AlasConnect LLC
 category:            Data
+build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md
 
 source-repository head


### PR DESCRIPTION
Loosened cabal version constraint to `>= 1.10`. I have no easy way to test with older versions of cabal, but since our in house apps as well as `servant` ([see here](https://hackage.haskell.org/package/servant-0.18.2/servant.cabal)) use this range it seems safe to do. Nothing defined in our cabal file should conflict with older version, at least from what I learned reading [this issue](https://github.com/haskell/cabal/issues/4899).